### PR TITLE
Testing refinements for 2-let-spec and 5-fat-arrows

### DIFF
--- a/tutorial/2-let-spec.js
+++ b/tutorial/2-let-spec.js
@@ -8,15 +8,22 @@ describe('let', function() {
     greeting: "hello!"
   };
 
-  for (var prop in object) {
-    var item = object[prop];
-  }
 
   it("shouldn't leak out of context", function() {
-    expect(item).to.be.undefined;
-    expect(item).to.not.equal("hello!");
-    expect(prop).to.be.undefined;
-    expect(prop).to.not.equal("greeting");
+    for (var prop in object) {
+      expect(prop).to.equal("greeting");
+
+      var item = object[prop];
+      expect(item).to.equal("hello!");
+    }
+
+    expect(function(){
+      return (prop);
+    }).to.throw(ReferenceError);
+
+    expect(function(){
+      return (item);
+    }).to.throw(ReferenceError);
   });
 
   it("should be possible to reassign a let, in different scope", function() {

--- a/tutorial/5-fat-arrow-spec.js
+++ b/tutorial/5-fat-arrow-spec.js
@@ -31,7 +31,7 @@ describe('fat arrow', () => {
       };
     }
     const fruits = ['apple', 'orange', 'apricot'];
-    const edibleFruitFilter = edible(/orange/);
+    const edibleFruitFilter = edible(/^(?!orange$)/);
     const edibleFruit = fruits.filter(edibleFruitFilter);
     expect(edibleFruit).to.eql(["apple", "apricot"]);
   });


### PR DESCRIPTION
In the 'let' test, the `expect(...).to.be.undefined`s were throwing errors, causing the intended changes for the exercise to still fail in error.  I've added assertions which check for the values within lexical scope, and outside that, expect(function(){...}).to.throw(ReferenceError) which is what should happen when using the 'let' keyword.

In the 'fat-arrows' test, I believe the regex was the wrong way around and that you intended for the regex filter to only return fruit _other_ than 'orange'.